### PR TITLE
fix: remove preinstall from svelte package

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -5,7 +5,6 @@
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package",
 		"preview": "vite preview",
-		"preinstall": "svelte-kit sync && svelte-package",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",


### PR DESCRIPTION
Since the update of `@git-diff-view/svelte` to `0.0.8`, it now fails to install. This is due to a preinstall that calls dependencies not installed yet.

This PR just removes the `preinstall` script as it is not required.