### PR TITLE
fix: handle identical old/new content

### DIFF
--- a/packages/core/src/parse/diff-parse.ts
+++ b/packages/core/src/parse/diff-parse.ts
@@ -442,12 +442,12 @@ export class DiffParser {
       let linesConsumed = 0;
       let previousHunk: DiffHunk | null = null;
 
-      do {
+      while (this.peek()) {
         const hunk = this.parseHunk(linesConsumed, hunks.length, previousHunk);
         hunks.push(hunk);
         previousHunk = hunk;
         linesConsumed += hunk.lines.length;
-      } while (this.peek());
+      }
 
       const contents = this.text
         .substring(headerEnd + 1, this.le)


### PR DESCRIPTION
Fix for https://github.com/MrWangJustToDo/git-diff-view/issues/16

When creating a diff file where `old` / `new` content is identical, currently there is a crash - because comparing the same content will have no hunks, and code always tries to create hunks.

This PR changes `diff-parse` from a `do`/`while` loop, to a `while` loop, to ensure `peek()` is called initially before trying to create hunks.

For the case content is identical, empty `hunks` array will be created instead of `Expected hunk header but reached end of diff` exception.

<details>

<summary>Test case to reproduce the bug / demonstrate the fix</summary>

```js
#!/usr/bin/env node

// build package first
import { generateDiffFile } from "./packages/file/index.js";

const identicalContent = `hello world
line 2
line 3`;

try {
  const diffFile = generateDiffFile(
    "test.txt",
    identicalContent,
    "test.txt",
    identicalContent,
    "txt",
    "txt"
  );

  diffFile.init();

  diffFile.buildSplitDiffLines();

  diffFile.buildUnifiedDiffLines();

  console.log(`diff file built:
- Additions: ${diffFile.additionLength}
- Deletions: ${diffFile.deletionLength}
- Split lines: ${diffFile.splitLineLength}
- Unified lines: ${diffFile.unifiedLineLength}`);
} catch (error) {
  console.error(`oh no: ${error.message}`, error);
}

```

</details>