### PR TITLE
fix(utils): use native removeAllRanges() to fix WebKit NotFoundError

### DIFF
--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -1,8 +1,5 @@
 export const removeAllSelection = () => {
-  const selection = window.getSelection();
-  for (let i = 0; i < selection.rangeCount; i++) {
-    selection.removeRange(selection.getRangeAt(i));
-  }
+  window.getSelection()?.removeAllRanges();
 };
 
 export const syncScroll = (left: HTMLElement, right: HTMLElement) => {


### PR DESCRIPTION
Fixes #56

## Problem

`removeAllSelection()` throws `NotFoundError` in WebKit (Safari) because the range object returned by `getRangeAt(0)` can become stale before `removeRange()` is called.

## Solution

Replace the manual loop with `removeAllRanges()` - the native DOM API designed for this exact purpose.

## Why this is safe

- `removeAllRanges()` is [supported in all browsers since 2015](https://developer.mozilla.org/en-US/docs/Web/API/Selection/removeAllRanges)
- Optional chaining handles SSR/null cases
- Atomic operation eliminates race conditions